### PR TITLE
wasm2c-nosandbox: remove OOB checks on load/store

### DIFF
--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -49,6 +49,11 @@
 #endif
 
 #if WABT_BIG_ENDIAN
+
+#ifdef NO_SANDBOX
+#error "Big endian is not supported in --no-sandbox mode"
+#endif
+
 static inline void load_data(void* dest, const void* src, size_t n) {
   size_t i = 0;
   u8* dest_chars = dest;
@@ -81,7 +86,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_rt_memcpy(&mem->data[mem->size - addr - sizeof(t1)], &wrapped, \
                    sizeof(t1));                                         \
   }
-#else
+#else  // WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
   memcpy(dest, src, n);
 }
@@ -90,6 +95,21 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
+#ifdef NO_SANDBOX
+#define DEFINE_LOAD(name, t1, t2, t3)                       \
+  static inline t3 name(u64 addr) {                         \
+    t1 result;                                              \
+    wasm_rt_memcpy(&result, (const void*)addr, sizeof(t1)); \
+    wasm_asm("" ::"r"(result));                             \
+    return (t3)(t2)result;                                  \
+  }
+
+#define DEFINE_STORE(name, t1, t2)                     \
+  static inline void name(u64 addr, t2 value) {        \
+    t1 wrapped = (t1)value;                            \
+    wasm_rt_memcpy((void*)addr, &wrapped, sizeof(t1)); \
+  }
+#else  // NO_SANDBOX
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
@@ -105,7 +125,8 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(&mem->data[addr], &wrapped, sizeof(t1));            \
   }
-#endif
+#endif  // NO_SANDBOX
+#endif  // WABT_BIG_ENDIAN
 
 DEFINE_LOAD(i32_load, u32, u32, u32)
 DEFINE_LOAD(i64_load, u64, u64, u64)

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -112,6 +112,9 @@ u32 Z_testZ_add(Z_test_instance_t*, u32, u32);
 #endif
 
 #if WABT_BIG_ENDIAN
+#ifdef NO_SANDBOX
+#error "Big endian is not supported in --no-sandbox mode"
+#endif
 static inline void load_data(void* dest, const void* src, size_t n) {
   size_t i = 0;
   u8* dest_chars = dest;
@@ -144,7 +147,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_rt_memcpy(&mem->data[mem->size - addr - sizeof(t1)], &wrapped, \
                    sizeof(t1));                                         \
   }
-#else
+#else  // WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
   memcpy(dest, src, n);
 }
@@ -153,6 +156,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
+#ifdef NO_SANDBOX
+#define DEFINE_LOAD(name, t1, t2, t3)                       \
+  static inline t3 name(u64 addr) {                         \
+    t1 result;                                              \
+    wasm_rt_memcpy(&result, (const void*)addr, sizeof(t1)); \
+    wasm_asm("" ::"r"(result));                             \
+    return (t3)(t2)result;                                  \
+  }
+#define DEFINE_STORE(name, t1, t2)                     \
+  static inline void name(u64 addr, t2 value) {        \
+    t1 wrapped = (t1)value;                            \
+    wasm_rt_memcpy((void*)addr, &wrapped, sizeof(t1)); \
+  }
+#else  // NO_SANDBOX
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
@@ -168,7 +185,8 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(&mem->data[addr], &wrapped, sizeof(t1));            \
   }
-#endif
+#endif  // NO_SANDBOX
+#endif  // WABT_BIG_ENDIAN
 
 DEFINE_LOAD(i32_load, u32, u32, u32)
 DEFINE_LOAD(i64_load, u64, u64, u64)

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -142,6 +142,9 @@ void Z_testZ__start(Z_test_instance_t*);
 #endif
 
 #if WABT_BIG_ENDIAN
+#ifdef NO_SANDBOX
+#error "Big endian is not supported in --no-sandbox mode"
+#endif
 static inline void load_data(void* dest, const void* src, size_t n) {
   size_t i = 0;
   u8* dest_chars = dest;
@@ -174,7 +177,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_rt_memcpy(&mem->data[mem->size - addr - sizeof(t1)], &wrapped, \
                    sizeof(t1));                                         \
   }
-#else
+#else  // WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
   memcpy(dest, src, n);
 }
@@ -183,6 +186,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
+#ifdef NO_SANDBOX
+#define DEFINE_LOAD(name, t1, t2, t3)                       \
+  static inline t3 name(u64 addr) {                         \
+    t1 result;                                              \
+    wasm_rt_memcpy(&result, (const void*)addr, sizeof(t1)); \
+    wasm_asm("" ::"r"(result));                             \
+    return (t3)(t2)result;                                  \
+  }
+#define DEFINE_STORE(name, t1, t2)                     \
+  static inline void name(u64 addr, t2 value) {        \
+    t1 wrapped = (t1)value;                            \
+    wasm_rt_memcpy((void*)addr, &wrapped, sizeof(t1)); \
+  }
+#else  // NO_SANDBOX
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
@@ -198,7 +215,9 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(&mem->data[addr], &wrapped, sizeof(t1));            \
   }
-#endif
+#endif  // NO_SANDBOX
+#endif  // WABT_BIG_ENDIAN
+
 
 DEFINE_LOAD(i32_load, u32, u32, u32)
 DEFINE_LOAD(i64_load, u64, u64, u64)

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -106,6 +106,9 @@ void Z_test_free(Z_test_instance_t*);
 #endif
 
 #if WABT_BIG_ENDIAN
+#ifdef NO_SANDBOX
+#error "Big endian is not supported in --no-sandbox mode"
+#endif
 static inline void load_data(void* dest, const void* src, size_t n) {
   size_t i = 0;
   u8* dest_chars = dest;
@@ -138,7 +141,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_rt_memcpy(&mem->data[mem->size - addr - sizeof(t1)], &wrapped, \
                    sizeof(t1));                                         \
   }
-#else
+#else  // WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
   memcpy(dest, src, n);
 }
@@ -147,6 +150,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
+#ifdef NO_SANDBOX
+#define DEFINE_LOAD(name, t1, t2, t3)                       \
+  static inline t3 name(u64 addr) {                         \
+    t1 result;                                              \
+    wasm_rt_memcpy(&result, (const void*)addr, sizeof(t1)); \
+    wasm_asm("" ::"r"(result));                             \
+    return (t3)(t2)result;                                  \
+  }
+#define DEFINE_STORE(name, t1, t2)                     \
+  static inline void name(u64 addr, t2 value) {        \
+    t1 wrapped = (t1)value;                            \
+    wasm_rt_memcpy((void*)addr, &wrapped, sizeof(t1)); \
+  }
+#else  // NO_SANDBOX
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
@@ -162,7 +179,9 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(&mem->data[addr], &wrapped, sizeof(t1));            \
   }
-#endif
+#endif  // NO_SANDBOX
+#endif  // WABT_BIG_ENDIAN
+
 
 DEFINE_LOAD(i32_load, u32, u32, u32)
 DEFINE_LOAD(i64_load, u64, u64, u64)


### PR DESCRIPTION
This commit removes OOB checks for load/store instructions in no-sandbox mode.