### PR TITLE
wasm2c-nosandbox: Remove instance parameter for functions

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1416,7 +1416,9 @@ void CWriter::WriteFuncDeclarations() {
 void CWriter::WriteFuncDeclaration(const FuncDeclaration& decl,
                                    const std::string& name) {
   Write(ResultType(decl.sig.result_types), " ", name, "(");
-  Write(ModuleInstanceTypeName(), "*");
+  if (!options_.no_sandbox) {
+    Write(ModuleInstanceTypeName(), "*");
+  }
   WriteParamTypes(decl);
   Write(")");
 }
@@ -1425,14 +1427,19 @@ void CWriter::WriteImportFuncDeclaration(const FuncDeclaration& decl,
                                          const std::string& module_name,
                                          const std::string& name) {
   Write(ResultType(decl.sig.result_types), " ", name, "(");
-  Write("struct ", MangleModuleInstanceTypeName(module_name), "*");
+  if (!options_.no_sandbox) {
+    Write("struct ", MangleModuleInstanceTypeName(module_name), "*");
+  }
   WriteParamTypes(decl);
   Write(")");
 }
 
 void CWriter::WriteCallIndirectFuncDeclaration(const FuncDeclaration& decl,
                                                const std::string& name) {
-  Write(ResultType(decl.sig.result_types), " ", name, "(void*");
+  Write(ResultType(decl.sig.result_types), " ", name, "(");
+  if (!options_.no_sandbox) {
+    Write("void*");
+  }
   WriteParamTypes(decl);
   Write(")");
 }
@@ -2045,13 +2052,14 @@ void CWriter::WriteExports(CWriterPhase kind) {
         Write(OpenBrace());
         Write("return ", ExternalRef(ModuleFieldType::Func, internal_name),
               "(");
-
-        bool is_import = import_module_sym_map_.count(internal_name) != 0;
-        if (is_import) {
-          Write("instance->", MangleModuleInstanceName(
-                                  import_module_sym_map_[internal_name]));
-        } else {
-          Write("instance");
+        if (!options_.no_sandbox) {
+          bool is_import = import_module_sym_map_.count(internal_name) != 0;
+          if (is_import) {
+            Write("instance->", MangleModuleInstanceName(
+                                    import_module_sym_map_[internal_name]));
+          } else {
+            Write("instance");
+          }
         }
         WriteParamSymbols(index_to_name);
         Write(CloseBrace(), Newline());
@@ -2374,11 +2382,20 @@ void CWriter::WriteParamsAndLocals() {
 }
 
 void CWriter::WriteParams(const std::vector<std::string>& index_to_name) {
-  Write(ModuleInstanceTypeName(), "* instance");
+  bool need_comma = false;
+  if (!options_.no_sandbox) {
+    Write(ModuleInstanceTypeName(), "* instance");
+    need_comma = true;
+  }
   if (func_->GetNumParams() != 0) {
     Indent(4);
     for (Index i = 0; i < func_->GetNumParams(); ++i) {
-      Write(", ");
+      if (need_comma) {
+        Write(", ");
+      } else {
+        need_comma = true;
+      }
+
       if (i != 0 && (i % 8) == 0) {
         Write(Newline());
       }
@@ -2390,10 +2407,15 @@ void CWriter::WriteParams(const std::vector<std::string>& index_to_name) {
 }
 
 void CWriter::WriteParamSymbols(const std::vector<std::string>& index_to_name) {
+  bool needs_comma = !options_.no_sandbox;
   if (func_->GetNumParams() != 0) {
     Indent(4);
     for (Index i = 0; i < func_->GetNumParams(); ++i) {
-      Write(", ");
+      if (needs_comma) {
+        Write(", ");
+      } else {
+        needs_comma = true;
+      }
       if (i != 0 && (i % 8) == 0) {
         Write(Newline());
       }
@@ -2405,9 +2427,14 @@ void CWriter::WriteParamSymbols(const std::vector<std::string>& index_to_name) {
 }
 
 void CWriter::WriteParamTypes(const FuncDeclaration& decl) {
+  bool needs_comma = !options_.no_sandbox;
   if (decl.GetNumParams() != 0) {
     for (Index i = 0; i < decl.GetNumParams(); ++i) {
-      Write(", ");
+      if (needs_comma) {
+        Write(", ");
+      } else {
+        needs_comma = true;
+      }
       Write(decl.GetParamType(i));
     }
   }
@@ -2724,15 +2751,23 @@ void CWriter::Write(const ExprList& exprs) {
 
         assert(var.is_name());
         Write(ExternalRef(ModuleFieldType::Func, var.name()), "(");
-        bool is_import = import_module_sym_map_.count(func.name) != 0;
-        if (is_import) {
-          Write("instance->",
-                MangleModuleInstanceName(import_module_sym_map_[func.name]));
-        } else {
-          Write("instance");
+        if (!options_.no_sandbox) {
+          bool is_import = import_module_sym_map_.count(func.name) != 0;
+          if (is_import) {
+            Write("instance->",
+                  MangleModuleInstanceName(import_module_sym_map_[func.name]));
+          } else {
+            Write("instance");
+          }
         }
+
+        bool needs_comma = !options_.no_sandbox;
         for (Index i = 0; i < num_params; ++i) {
-          Write(", ");
+          if (needs_comma) {
+            Write(", ");
+          } else {
+            needs_comma = true;
+          }
           Write(StackVar(num_params - i - 1));
         }
         Write(");", Newline());

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -726,6 +726,35 @@ DEFINE_TABLE_SET(externref)
 DEFINE_TABLE_FILL(funcref)
 DEFINE_TABLE_FILL(externref)
 
+#ifdef NO_SANDBOX
+// TODO: This is a temporary workaround for env module, remove them if they are
+//  not needed or replace with proper implementation
+struct Z_env_instance_t {};
+
+wasm_rt_funcref_table_t* Z_envZ___indirect_function_table(
+    struct Z_env_instance_t* unused) {
+  return NULL;
+}
+
+u64* Z_envZ___memory_base(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+
+u64* Z_envZ___table_base(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+
+u32* Z_envZ___table_base32(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+
+wasm_rt_memory_t* Z_envZ_memory(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+
+// END OF evn workaround
+#endif  // NO_SANDBOX
+
 #if defined(__GNUC__) || defined(__clang__)
 #define FUNC_TYPE_T(x) static const char* const x
 #else

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -115,7 +115,7 @@ def IsModuleCommand(command):
 
 class CWriter(object):
 
-    def __init__(self, spec_json, prefix, out_file, out_dir):
+    def __init__(self, spec_json, prefix, out_file, out_dir, no_sandbox):
         self.source_filename = os.path.basename(spec_json['source_filename'])
         self.commands = spec_json['commands']
         self.out_file = out_file
@@ -124,6 +124,7 @@ class CWriter(object):
         self.module_idx = 0
         self.module_name_to_idx = {}
         self.module_prefix_map = {}
+        self.no_sandbox = no_sandbox
         self.unmangled_names = {}
         self.idx_to_module_name = {}
         self._MaybeWriteDummyModule()
@@ -254,6 +255,8 @@ class CWriter(object):
 
     def _WriteModuleCommand(self, command):
         self.module_idx += 1
+        if self.no_sandbox:
+            return
         self._WriteModuleInitCall(command, False)
 
     def _WriteModuleInstances(self):
@@ -264,11 +267,15 @@ class CWriter(object):
                 idx += 1
 
     def _WriteModuleCleanUps(self):
+        if self.no_sandbox:
+            return
         for idx in range(self.module_idx):
             self.out_file.write("%s_free(&%s_instance);\n" % (self.GetModulePrefix(idx), self.GetModulePrefix(idx)))
 
     def _WriteAssertUninstantiableCommand(self, command):
         self.module_idx += 1
+        if self.no_sandbox:
+            return
         self._WriteModuleInitCall(command, True)
 
     def _WriteActionCommand(self, command):
@@ -425,10 +432,16 @@ class CWriter(object):
         field = mangled_module_name + MangleName(action['field'])
         if type_ == 'invoke':
             args = self._ConstantList(action.get('args', []))
-            if len(args) == 0:
-                args = f'&{mangled_module_name}_instance'
+            if self.no_sandbox:
+                if len(args) == 0:
+                    args = f''
+                else:
+                    args = f'{args}'
             else:
-                args = f'&{mangled_module_name}_instance, {args}'
+                if len(args) == 0:
+                    args = f'&{mangled_module_name}_instance'
+                else:
+                    args = f'&{mangled_module_name}_instance, {args}'
             return '%s(%s)' % (field, args)
         elif type_ == 'get':
             return '*%s(%s)' % (field, '&' + mangled_module_name + '_instance')
@@ -576,7 +589,7 @@ def main(args):
                 prefix = prefix_file.read() + '\n'
 
         output = io.StringIO()
-        cwriter = CWriter(spec_json, prefix, output, out_dir)
+        cwriter = CWriter(spec_json, prefix, output, out_dir, options.no_sandbox)
 
         o_filenames = []
         cflags = ['-I%s' % options.wasmrt_dir, '-I%s' % options.simde_dir]

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -798,6 +798,28 @@ DEFINE_TABLE_SET(externref)
 
 DEFINE_TABLE_FILL(funcref)
 DEFINE_TABLE_FILL(externref)
+#ifdef NO_SANDBOX
+// TODO: This is a temporary workaround for env module, remove them if they are
+//  not needed or replace with proper implementation
+struct Z_env_instance_t {};
+wasm_rt_funcref_table_t* Z_envZ___indirect_function_table(
+    struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u64* Z_envZ___memory_base(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u64* Z_envZ___table_base(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u32* Z_envZ___table_base32(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+wasm_rt_memory_t* Z_envZ_memory(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+// END OF evn workaround
+#endif  // NO_SANDBOX
 
 #if defined(__GNUC__) || defined(__clang__)
 #define FUNC_TYPE_T(x) static const char* const x

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -828,6 +828,28 @@ DEFINE_TABLE_SET(externref)
 
 DEFINE_TABLE_FILL(funcref)
 DEFINE_TABLE_FILL(externref)
+#ifdef NO_SANDBOX
+// TODO: This is a temporary workaround for env module, remove them if they are
+//  not needed or replace with proper implementation
+struct Z_env_instance_t {};
+wasm_rt_funcref_table_t* Z_envZ___indirect_function_table(
+    struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u64* Z_envZ___memory_base(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u64* Z_envZ___table_base(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u32* Z_envZ___table_base32(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+wasm_rt_memory_t* Z_envZ_memory(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+// END OF evn workaround
+#endif  // NO_SANDBOX
 
 #if defined(__GNUC__) || defined(__clang__)
 #define FUNC_TYPE_T(x) static const char* const x

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -792,6 +792,28 @@ DEFINE_TABLE_SET(externref)
 
 DEFINE_TABLE_FILL(funcref)
 DEFINE_TABLE_FILL(externref)
+#ifdef NO_SANDBOX
+// TODO: This is a temporary workaround for env module, remove them if they are
+//  not needed or replace with proper implementation
+struct Z_env_instance_t {};
+wasm_rt_funcref_table_t* Z_envZ___indirect_function_table(
+    struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u64* Z_envZ___memory_base(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u64* Z_envZ___table_base(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+u32* Z_envZ___table_base32(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+wasm_rt_memory_t* Z_envZ_memory(struct Z_env_instance_t* unused) {
+  return NULL;
+}
+// END OF evn workaround
+#endif  // NO_SANDBOX
 
 #if defined(__GNUC__) || defined(__clang__)
 #define FUNC_TYPE_T(x) static const char* const x

--- a/test/wasm2c/no-sandbox/stack-pointer-shared.txt
+++ b/test/wasm2c/no-sandbox/stack-pointer-shared.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-spec-wasm2c
+;;; ARGS: --debug-names --experimental --enable-memory64 --no-sandbox
+;;; STDIN_FILE: test/wasm2c/no-sandbox/wast/stack_pointer_shared.wast
+(;; STDOUT ;;;
+2/2 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/no-sandbox/wast/stack_pointer_shared.wast
+++ b/test/wasm2c/no-sandbox/wast/stack_pointer_shared.wast
@@ -1,0 +1,78 @@
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (param i64 i32)))
+  (type (;2;) (func (param i32 i32) (result i32)))
+  (import "env" "memory" (memory (;0;) i64 0))
+  (import "env" "__indirect_function_table" (table (;0;) 0 funcref))
+  (import "env" "__stack_pointer" (global $__stack_pointer (mut i64)))
+  (import "env" "__memory_base" (global $__memory_base i64))
+  (import "env" "__table_base" (global $__table_base i64))
+  (import "env" "__table_base32" (global $__table_base32 i32))
+  (func $__wasm_call_ctors (type 0)
+    call $__wasm_apply_data_relocs)
+  (func $__wasm_apply_data_relocs (type 0))
+  (func $store_char*__char_ (type 1) (param i64 i32)
+    local.get 0
+    local.get 1
+    i32.store8)
+  (func $get_from_stack (type 2) (param i32 i32) (result i32)
+    (local i64 i64 i64 i64)
+    global.get $__stack_pointer
+    local.tee 2
+    local.set 3
+    local.get 2
+    local.get 0
+    i64.extend_i32_s
+    i64.const 15
+    i64.add
+    i64.const -16
+    i64.and
+    i64.sub
+    local.tee 4
+    global.set $__stack_pointer
+    block  ;; label = @1
+      block  ;; label = @2
+        local.get 0
+        br_if 0 (;@2;)
+        i32.const 0
+        local.set 0
+        br 1 (;@1;)
+      end
+      local.get 0
+      i64.extend_i32_u
+      local.set 5
+      i64.const 0
+      local.set 2
+      loop  ;; label = @2
+        local.get 4
+        local.get 2
+        i64.add
+        local.get 2
+        i64.const 1
+        i64.add
+        local.tee 2
+        i32.wrap_i64
+        i32.const 24
+        i32.shl
+        i32.const 24
+        i32.shr_s
+        call $store_char*__char_
+        local.get 5
+        local.get 2
+        i64.ne
+        br_if 0 (;@2;)
+      end
+      local.get 4
+      local.get 1
+      i64.extend_i32_s
+      i64.add
+      i32.load8_s
+      local.set 0
+    end
+    local.get 3
+    global.set $__stack_pointer
+    local.get 0)
+  (export "get_from_stack" (func $get_from_stack)))
+
+(assert_return (invoke "get_from_stack"(i32.const 16)(i32.const 0)) (i32.const 1))
+(assert_return (invoke "get_from_stack"(i32.const 16)(i32.const 5)) (i32.const 6))


### PR DESCRIPTION
Also make the tests work on no-sandbox mode and add a test for -shared module. This makes more no-sandbox things testable.