### PR TITLE
Propagates no_sandbox flag to binary reader.

### DIFF
--- a/include/wabt/binary-reader.h
+++ b/include/wabt/binary-reader.h
@@ -37,12 +37,26 @@ struct ReadBinaryOptions {
                     Stream* log_stream,
                     bool read_debug_names,
                     bool stop_on_first_error,
+                    bool fail_on_custom_section_error,
+                    bool no_sandbox)
+      : features(features),
+        log_stream(log_stream),
+        read_debug_names(read_debug_names),
+        stop_on_first_error(stop_on_first_error),
+        fail_on_custom_section_error(fail_on_custom_section_error),
+        no_sandbox(no_sandbox) {}
+
+  ReadBinaryOptions(const Features& features,
+                    Stream* log_stream,
+                    bool read_debug_names,
+                    bool stop_on_first_error,
                     bool fail_on_custom_section_error)
       : features(features),
         log_stream(log_stream),
         read_debug_names(read_debug_names),
         stop_on_first_error(stop_on_first_error),
-        fail_on_custom_section_error(fail_on_custom_section_error) {}
+        fail_on_custom_section_error(fail_on_custom_section_error),
+        no_sandbox(false) {}
 
   Features features;
   Stream* log_stream = nullptr;
@@ -50,6 +64,7 @@ struct ReadBinaryOptions {
   bool stop_on_first_error = true;
   bool fail_on_custom_section_error = true;
   bool skip_function_bodies = false;
+  bool no_sandbox = false;
 };
 
 // TODO: Move somewhere else?

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -92,7 +92,10 @@ class CodeMetadataExprQueue {
 
 class BinaryReaderIR : public BinaryReaderNop {
  public:
-  BinaryReaderIR(Module* out_module, const char* filename, Errors* errors);
+  BinaryReaderIR(Module* out_module,
+                 const char* filename,
+                 Errors* errors,
+                 const ReadBinaryOptions& options);
 
   bool OnError(const Error&) override;
 
@@ -384,12 +387,18 @@ class BinaryReaderIR : public BinaryReaderNop {
 
   CodeMetadataExprQueue code_metadata_queue_;
   std::string_view current_metadata_name_;
+
+  const ReadBinaryOptions& options_;
 };
 
 BinaryReaderIR::BinaryReaderIR(Module* out_module,
                                const char* filename,
-                               Errors* errors)
-    : errors_(errors), module_(out_module), filename_(filename) {}
+                               Errors* errors,
+                               const ReadBinaryOptions& options)
+    : errors_(errors),
+      module_(out_module),
+      filename_(filename),
+      options_(options) {}
 
 Location BinaryReaderIR::GetLocation() const {
   Location loc;
@@ -1700,7 +1709,7 @@ Result ReadBinaryIr(const char* filename,
                     const ReadBinaryOptions& options,
                     Errors* errors,
                     Module* out_module) {
-  BinaryReaderIR reader(out_module, filename, errors);
+  BinaryReaderIR reader(out_module, filename, errors, options);
   return ReadBinary(data, size, &reader, options);
 }
 

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -153,9 +153,9 @@ int ProgramMain(int argc, char** argv) {
     Module module;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = true;
-    ReadBinaryOptions options(s_features, s_log_stream.get(),
-                              s_read_debug_names, kStopOnFirstError,
-                              kFailOnCustomSectionError);
+    ReadBinaryOptions options(
+        s_features, s_log_stream.get(), s_read_debug_names, kStopOnFirstError,
+        kFailOnCustomSectionError, s_write_c_options.no_sandbox);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {


### PR DESCRIPTION
Adds the no_sandbox option to ReadBinaryOptions and arranges for it to be populated identically to WriteCOptions in wasm2c.

Furthermore, propagates ReadBinaryOptions to BinaryReaderIR.

This is useful to have around in the reader since no-sandbox mode only applies to modules that satisfy certain invariants.  We should generate error messages when those invariants are not satisfied, but only in no_sandbox mode.
Moreover, we can avoid the work of populating data structures that are only used in no_sandbox mode when they are not needed.