### PR TITLE
Handle external data

### DIFF
--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -1255,35 +1255,40 @@ struct Module {
 
   // Mappings from a symbol index (pointing into the symbol table from the
   // "linking" section) to their corresponding function- and data segment index.
-  std::unordered_map<Index, Index> function_index_by_symbol_index_;
-  std::unordered_map<Index, Index> data_segment_index_by_symbol_index_;
+  std::unordered_map<Index, Index> function_symbols_;
+  std::unordered_map<Index, Index> data_symbols_;
+
+  // Mapping from a data symbol index to its name.  This mapping is only
+  // constructed for data symbols that are marked undefined.
+  std::unordered_map<Index, std::string> undefined_data_symbols_;
 
   // Mapping from offsets of function pointer loads (operands of ixx.const
   // instructions) to their correpsonding function relocation information,
-  // represented simply by the function index.
+  // represented simply by the function symbol index.
   std::unordered_map<Offset, Index>
-      function_reloc_by_function_pointer_load_offset_;
+      function_symbol_by_function_pointer_load_offset_;
 
   // Mappings (ordered) from offsets of 32- and 64-bit function pointers within
   // global data initializers to their corresponding function relocation
-  // information, represented simply by the function index.
-  std::map<Offset, Index> function_reloc_by_fptr32_init_offset_;
-  std::map<Offset, Index> function_reloc_by_fptr64_init_offset_;
+  // information, represented simply by the function symbol index.
+  std::map<Offset, Index> function_symbol_by_fptr32_init_offset_;
+  std::map<Offset, Index> function_symbol_by_fptr64_init_offset_;
 
   // Mapping from offsets of memory pointer loads (operands of ixx.const
   // instructions) to their corresponding data relocation information,
-  // represented by a pair consisting of the data segment index and the offset.
+  // represented by a pair consisting of the data segment symbol index and the
+  // offset.
   std::unordered_map<Offset, std::pair<Index, uint32_t>>
-      data_reloc_by_memory_pointer_load_offset_;
+      data_symbol_and_addend_by_memory_pointer_load_offset_;
 
   // Mapping from (ordered) offsets of 32- and 64-bit memory pointers within
   // global data initializers to their corresponding data relocation
-  // information, represented by a pair consisting of the data segment index and
-  // the offset.
+  // information, represented by a pair consisting of the data segment symbol
+  // index and the offset.
   std::map<Offset, std::pair<Index, uint32_t>>
-      data_reloc_by_mptr32_init_offset_;
+      data_symbol_and_addend_by_mptr32_init_offset_;
   std::map<Offset, std::pair<Index, uint32_t>>
-      data_reloc_by_mptr64_init_offset_;
+      data_symbol_and_addend_by_mptr64_init_offset_;
 };
 
 enum class ScriptModuleType {

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1565,25 +1565,6 @@ Result BinaryReaderIR::OnNameEntry(NameSectionSubsection type,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::ValidateFunctionSymbol(Index symbol_index) {
-  if (module_->function_index_by_symbol_index_.find(symbol_index) ==
-      module_->function_index_by_symbol_index_.end()) {
-    PrintError("expected function symbol index, found %" PRIindex,
-               symbol_index);
-    return Result::Error;
-  }
-  return Result::Ok;
-}
-
-Result BinaryReaderIR::ValidateDataSegmentSymbol(Index symbol_index) {
-  if (module_->data_segment_index_by_symbol_index_.find(symbol_index) ==
-      module_->data_segment_index_by_symbol_index_.end()) {
-    PrintError("expected data segment index, found %" PRIindex, symbol_index);
-    return Result::Error;
-  }
-  return Result::Ok;
-}
-
 Result BinaryReaderIR::OnReloc(RelocType type,
                                Offset offset,
                                Index index,
@@ -1594,38 +1575,28 @@ Result BinaryReaderIR::OnReloc(RelocType type,
   switch (type) {
     case RelocType::TableIndexSLEB:
     case RelocType::TableIndexSLEB64:
-      CHECK_RESULT(ValidateFunctionSymbol(index));
-      module_->function_reloc_by_function_pointer_load_offset_[offset] =
-          module_->function_index_by_symbol_index_[index];
+      module_->function_symbol_by_function_pointer_load_offset_[offset] = index;
       break;
     case RelocType::TableIndexI32:
-      CHECK_RESULT(ValidateFunctionSymbol(index));
-      module_->function_reloc_by_fptr32_init_offset_[offset] =
-          module_->function_index_by_symbol_index_[index];
+      module_->function_symbol_by_fptr32_init_offset_[offset] = index;
       break;
     case RelocType::TableIndexI64:
-      CHECK_RESULT(ValidateFunctionSymbol(index));
-      module_->function_reloc_by_fptr64_init_offset_[offset] =
-          module_->function_index_by_symbol_index_[index];
+      module_->function_symbol_by_fptr64_init_offset_[offset] = index;
       break;
     case RelocType::MemoryAddressSLEB:
     case RelocType::MemoryAddressSLEB64:
     case RelocType::MemoryAddressLEB:
     case RelocType::MemoryAddressLEB64:
-      CHECK_RESULT(ValidateDataSegmentSymbol(index));
-      module_->data_reloc_by_memory_pointer_load_offset_[offset] =
-          std::make_pair(module_->data_segment_index_by_symbol_index_[index],
-                         addend);
+      module_->data_symbol_and_addend_by_memory_pointer_load_offset_[offset] =
+          std::make_pair(index, addend);
       break;
     case RelocType::MemoryAddressI32:
-      CHECK_RESULT(ValidateDataSegmentSymbol(index));
-      module_->data_reloc_by_mptr32_init_offset_[offset] = std::make_pair(
-          module_->data_segment_index_by_symbol_index_[index], addend);
+      module_->data_symbol_and_addend_by_mptr32_init_offset_[offset] =
+          std::make_pair(index, addend);
       break;
     case RelocType::MemoryAddressI64:
-      CHECK_RESULT(ValidateDataSegmentSymbol(index));
-      module_->data_reloc_by_mptr64_init_offset_[offset] = std::make_pair(
-          module_->data_segment_index_by_symbol_index_[index], addend);
+      module_->data_symbol_and_addend_by_mptr64_init_offset_[offset] =
+          std::make_pair(index, addend);
       break;
     default:
       break;
@@ -1702,13 +1673,14 @@ Result BinaryReaderIR::OnDataSymbol(Index index,
                                     uint32_t size) {
   if (flags & WABT_SYMBOL_FLAG_UNDEFINED) {
     // Refers to data in another file, `segment` not valid.
+    module_->undefined_data_symbols_[index] = name;
     return Result::Ok;
   }
   if (segment >= module_->data_segments.size()) {
     PrintError("invalid data segment index: %" PRIindex, segment);
     return Result::Error;
   }
-  module_->data_segment_index_by_symbol_index_[index] = segment;
+  module_->data_symbols_[index] = segment;
   if (name.empty()) {
     return Result::Ok;
   }
@@ -1733,7 +1705,7 @@ Result BinaryReaderIR::OnFunctionSymbol(Index index,
     PrintError("invalid function index: %" PRIindex, func_index);
     return Result::Error;
   }
-  module_->function_index_by_symbol_index_[index] = func_index;
+  module_->function_symbols_[index] = func_index;
   if (name.empty()) {
     return Result::Ok;
   }

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1565,6 +1565,26 @@ Result BinaryReaderIR::OnNameEntry(NameSectionSubsection type,
   return Result::Ok;
 }
 
+Result BinaryReaderIR::ValidateFunctionSymbol(Index symbol_index) {
+  if (module_->function_symbols_.find(symbol_index) ==
+      module_->function_symbols_.end()) {
+    PrintError("unexpected function symbol with index %u\n", symbol_index);
+    return Result::Error;
+  }
+  return Result::Ok;
+}
+
+Result BinaryReaderIR::ValidateDataSegmentSymbol(Index symbol_index) {
+  if (module_->data_symbols_.find(symbol_index) ==
+          module_->data_symbols_.end() &&
+      module_->undefined_data_symbols_.find(symbol_index) ==
+          module_->undefined_data_symbols_.end()) {
+    PrintError("unexpected data segment symbol with index %u\n", symbol_index);
+    return Result::Error;
+  }
+  return Result::Ok;
+}
+
 Result BinaryReaderIR::OnReloc(RelocType type,
                                Offset offset,
                                Index index,
@@ -1575,26 +1595,32 @@ Result BinaryReaderIR::OnReloc(RelocType type,
   switch (type) {
     case RelocType::TableIndexSLEB:
     case RelocType::TableIndexSLEB64:
+      CHECK_RESULT(ValidateFunctionSymbol(index));
       module_->function_symbol_by_function_pointer_load_offset_[offset] = index;
       break;
     case RelocType::TableIndexI32:
+      CHECK_RESULT(ValidateFunctionSymbol(index));
       module_->function_symbol_by_fptr32_init_offset_[offset] = index;
       break;
     case RelocType::TableIndexI64:
+      CHECK_RESULT(ValidateFunctionSymbol(index));
       module_->function_symbol_by_fptr64_init_offset_[offset] = index;
       break;
     case RelocType::MemoryAddressSLEB:
     case RelocType::MemoryAddressSLEB64:
     case RelocType::MemoryAddressLEB:
     case RelocType::MemoryAddressLEB64:
+      CHECK_RESULT(ValidateDataSegmentSymbol(index));
       module_->data_symbol_and_addend_by_memory_pointer_load_offset_[offset] =
           std::make_pair(index, addend);
       break;
     case RelocType::MemoryAddressI32:
+      CHECK_RESULT(ValidateDataSegmentSymbol(index));
       module_->data_symbol_and_addend_by_mptr32_init_offset_[offset] =
           std::make_pair(index, addend);
       break;
     case RelocType::MemoryAddressI64:
+      CHECK_RESULT(ValidateDataSegmentSymbol(index));
       module_->data_symbol_and_addend_by_mptr64_init_offset_[offset] =
           std::make_pair(index, addend);
       break;


### PR DESCRIPTION
I had to change the way relocation data is represented in the IR.  The problem is that for external data segments there is no corresponding data_segments entry.  For these situations I'm now just storing the name itself.

Because of the absence of these undefined data segments I cannot "denormalize" the mapping from offsets to data segment indices.  Instead, we now keep a mapping from offset to symbol(-index) and separately a mapping from symbol index to the actual entry in the relevant data structure (funcs or data_segments).

(For external data segments we will have to figure out the correct naming later in order to make linking work.  Using the original name feels correct for the time being.)