### PR TITLE
Render indirect calls directly in no-sandbox mode.

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2710,7 +2710,7 @@ void CWriter::Write(const ExprList& exprs) {
           Write(StackVar(num_params, decl.GetResultType(0)), " = ");
         }
 
-        bool needs_initial_comma = false;
+        bool needs_comma = false;
         if (options_.no_sandbox) {
           Write("((");
           WriteCallIndirectFuncDeclaration(decl, "(*)");
@@ -2728,11 +2728,13 @@ void CWriter::Write(const ExprList& exprs) {
           Write(", ", FuncTypeExpr(func_type), ", ", StackVar(0));
           Write(", ", ExternalInstanceRef(ModuleFieldType::Table, table->name),
                 ".data[", StackVar(0), "].module_instance");
-          needs_initial_comma = true;
+          needs_comma = true;
         }
         for (Index i = 0; i < num_params; ++i) {
-          if (needs_initial_comma || i > 0) {
+          if (needs_comma) {
             Write(", ");
+          } else {
+            needs_comma = true;
           }
           Write(StackVar(num_params - i));
         }

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2710,6 +2710,7 @@ void CWriter::Write(const ExprList& exprs) {
           Write(StackVar(num_params, decl.GetResultType(0)), " = ");
         }
 
+        bool needs_initial_comma = false;
         if (options_.no_sandbox) {
           Write("((");
           WriteCallIndirectFuncDeclaration(decl, "(*)");
@@ -2727,12 +2728,10 @@ void CWriter::Write(const ExprList& exprs) {
           Write(", ", FuncTypeExpr(func_type), ", ", StackVar(0));
           Write(", ", ExternalInstanceRef(ModuleFieldType::Table, table->name),
                 ".data[", StackVar(0), "].module_instance");
-          if (num_params > 0) {
-            Write(", ");
-          }
+          needs_initial_comma = true;
         }
         for (Index i = 0; i < num_params; ++i) {
-          if (i > 0) {
+          if (needs_initial_comma || i > 0) {
             Write(", ");
           }
           Write(StackVar(num_params - i));

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -28,7 +28,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
 
-#endif // NO_SANDBOX
+#endif  // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64
 #define RANGE_CHECK(mem, offset, len)              \

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -20,11 +20,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   return (a == b) || LIKELY(a && b && !memcmp(a, b, 32));
 }
 
+#ifndef NO_SANDBOX
+
 #define CALL_INDIRECT(table, t, ft, x, ...)              \
   (LIKELY((x) < table.size && table.data[x].func &&      \
           func_types_eq(ft, table.data[x].func_type)) || \
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
+
+#endif // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64
 #define RANGE_CHECK(mem, offset, len)              \

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -21,13 +21,11 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 }
 
 #ifndef NO_SANDBOX
-
 #define CALL_INDIRECT(table, t, ft, x, ...)              \
   (LIKELY((x) < table.size && table.data[x].func &&      \
           func_types_eq(ft, table.data[x].func_type)) || \
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
-
 #endif  // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -93,11 +93,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   return (a == b) || LIKELY(a && b && !memcmp(a, b, 32));
 }
 
+#ifndef NO_SANDBOX
+
 #define CALL_INDIRECT(table, t, ft, x, ...)              \
   (LIKELY((x) < table.size && table.data[x].func &&      \
           func_types_eq(ft, table.data[x].func_type)) || \
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
+
+#endif // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64
 #define RANGE_CHECK(mem, offset, len)              \
@@ -127,9 +131,11 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #if WABT_BIG_ENDIAN
+
 #ifdef NO_SANDBOX
 #error "Big endian is not supported in --no-sandbox mode"
 #endif
+
 static inline void load_data(void* dest, const void* src, size_t n) {
   if (!n) {
     return;
@@ -185,6 +191,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_asm("" ::"r"(result));                             \
     return (t3)(t2)result;                                  \
   }
+
 #define DEFINE_STORE(name, t1, t2)                     \
   static inline void name(u64 addr, t2 value) {        \
     t1 wrapped = (t1)value;                            \

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -127,9 +127,11 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #if WABT_BIG_ENDIAN
+
 #ifdef NO_SANDBOX
 #error "Big endian is not supported in --no-sandbox mode"
 #endif
+
 static inline void load_data(void* dest, const void* src, size_t n) {
   if (!n) {
     return;
@@ -185,6 +187,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_asm("" ::"r"(result));                             \
     return (t3)(t2)result;                                  \
   }
+
 #define DEFINE_STORE(name, t1, t2)                     \
   static inline void name(u64 addr, t2 value) {        \
     t1 wrapped = (t1)value;                            \

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -94,14 +94,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 }
 
 #ifndef NO_SANDBOX
-
 #define CALL_INDIRECT(table, t, ft, x, ...)              \
   (LIKELY((x) < table.size && table.data[x].func &&      \
           func_types_eq(ft, table.data[x].func_type)) || \
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
-
-#endif // NO_SANDBOX
+#endif  // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -123,11 +123,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   return (a == b) || LIKELY(a && b && !memcmp(a, b, 32));
 }
 
+#ifndef NO_SANDBOX
+
 #define CALL_INDIRECT(table, t, ft, x, ...)              \
   (LIKELY((x) < table.size && table.data[x].func &&      \
           func_types_eq(ft, table.data[x].func_type)) || \
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
+
+#endif // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64
 #define RANGE_CHECK(mem, offset, len)              \
@@ -157,9 +161,11 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #if WABT_BIG_ENDIAN
+
 #ifdef NO_SANDBOX
 #error "Big endian is not supported in --no-sandbox mode"
 #endif
+
 static inline void load_data(void* dest, const void* src, size_t n) {
   if (!n) {
     return;
@@ -215,6 +221,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_asm("" ::"r"(result));                             \
     return (t3)(t2)result;                                  \
   }
+
 #define DEFINE_STORE(name, t1, t2)                     \
   static inline void name(u64 addr, t2 value) {        \
     t1 wrapped = (t1)value;                            \
@@ -238,7 +245,6 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif  // NO_SANDBOX
 #endif  // WABT_BIG_ENDIAN
-
 
 DEFINE_LOAD(i32_load, u32, u32, u32)
 DEFINE_LOAD(i64_load, u64, u64, u64)

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -124,14 +124,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 }
 
 #ifndef NO_SANDBOX
-
 #define CALL_INDIRECT(table, t, ft, x, ...)              \
   (LIKELY((x) < table.size && table.data[x].func &&      \
           func_types_eq(ft, table.data[x].func_type)) || \
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
-
-#endif // NO_SANDBOX
+#endif  // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -157,9 +157,11 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #if WABT_BIG_ENDIAN
+
 #ifdef NO_SANDBOX
 #error "Big endian is not supported in --no-sandbox mode"
 #endif
+
 static inline void load_data(void* dest, const void* src, size_t n) {
   if (!n) {
     return;
@@ -215,6 +217,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_asm("" ::"r"(result));                             \
     return (t3)(t2)result;                                  \
   }
+
 #define DEFINE_STORE(name, t1, t2)                     \
   static inline void name(u64 addr, t2 value) {        \
     t1 wrapped = (t1)value;                            \
@@ -238,7 +241,6 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif  // NO_SANDBOX
 #endif  // WABT_BIG_ENDIAN
-
 
 DEFINE_LOAD(i32_load, u32, u32, u32)
 DEFINE_LOAD(i64_load, u64, u64, u64)

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -87,11 +87,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   return (a == b) || LIKELY(a && b && !memcmp(a, b, 32));
 }
 
+#ifndef NO_SANDBOX
+
 #define CALL_INDIRECT(table, t, ft, x, ...)              \
   (LIKELY((x) < table.size && table.data[x].func &&      \
           func_types_eq(ft, table.data[x].func_type)) || \
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
+
+#endif // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64
 #define RANGE_CHECK(mem, offset, len)              \
@@ -121,9 +125,11 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #if WABT_BIG_ENDIAN
+
 #ifdef NO_SANDBOX
 #error "Big endian is not supported in --no-sandbox mode"
 #endif
+
 static inline void load_data(void* dest, const void* src, size_t n) {
   if (!n) {
     return;
@@ -179,6 +185,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_asm("" ::"r"(result));                             \
     return (t3)(t2)result;                                  \
   }
+
 #define DEFINE_STORE(name, t1, t2)                     \
   static inline void name(u64 addr, t2 value) {        \
     t1 wrapped = (t1)value;                            \
@@ -202,7 +209,6 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif  // NO_SANDBOX
 #endif  // WABT_BIG_ENDIAN
-
 
 DEFINE_LOAD(i32_load, u32, u32, u32)
 DEFINE_LOAD(i64_load, u64, u64, u64)

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -88,14 +88,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 }
 
 #ifndef NO_SANDBOX
-
 #define CALL_INDIRECT(table, t, ft, x, ...)              \
   (LIKELY((x) < table.size && table.data[x].func &&      \
           func_types_eq(ft, table.data[x].func_type)) || \
        TRAP(CALL_INDIRECT),                              \
    ((t)table.data[x].func)(__VA_ARGS__))
-
-#endif // NO_SANDBOX
+#endif  // NO_SANDBOX
 
 #ifdef SUPPORT_MEMORY64
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -121,9 +121,11 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #if WABT_BIG_ENDIAN
+
 #ifdef NO_SANDBOX
 #error "Big endian is not supported in --no-sandbox mode"
 #endif
+
 static inline void load_data(void* dest, const void* src, size_t n) {
   if (!n) {
     return;
@@ -179,6 +181,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     wasm_asm("" ::"r"(result));                             \
     return (t3)(t2)result;                                  \
   }
+
 #define DEFINE_STORE(name, t1, t2)                     \
   static inline void name(u64 addr, t2 value) {        \
     t1 wrapped = (t1)value;                            \
@@ -202,7 +205,6 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif  // NO_SANDBOX
 #endif  // WABT_BIG_ENDIAN
-
 
 DEFINE_LOAD(i32_load, u32, u32, u32)
 DEFINE_LOAD(i64_load, u64, u64, u64)


### PR DESCRIPTION
This removes the use of the CALL_INDIRECT macro in no-sandbox mode.
It also avoids mentioning any tables or any function type variables.  These will go away in a separate PR.