### PR TITLE
Sandbox feature

### DIFF
--- a/include/wabt/binary-reader.h
+++ b/include/wabt/binary-reader.h
@@ -33,18 +33,6 @@ class Stream;
 
 struct ReadBinaryOptions {
   ReadBinaryOptions() = default;
-  ReadBinaryOptions(const Features& features,
-                    Stream* log_stream,
-                    bool read_debug_names,
-                    bool stop_on_first_error,
-                    bool fail_on_custom_section_error,
-                    bool no_sandbox)
-      : features(features),
-        log_stream(log_stream),
-        read_debug_names(read_debug_names),
-        stop_on_first_error(stop_on_first_error),
-        fail_on_custom_section_error(fail_on_custom_section_error),
-        no_sandbox(no_sandbox) {}
 
   ReadBinaryOptions(const Features& features,
                     Stream* log_stream,
@@ -55,8 +43,7 @@ struct ReadBinaryOptions {
         log_stream(log_stream),
         read_debug_names(read_debug_names),
         stop_on_first_error(stop_on_first_error),
-        fail_on_custom_section_error(fail_on_custom_section_error),
-        no_sandbox(false) {}
+        fail_on_custom_section_error(fail_on_custom_section_error) {}
 
   Features features;
   Stream* log_stream = nullptr;
@@ -64,7 +51,6 @@ struct ReadBinaryOptions {
   bool stop_on_first_error = true;
   bool fail_on_custom_section_error = true;
   bool skip_function_bodies = false;
-  bool no_sandbox = false;
 };
 
 // TODO: Move somewhere else?

--- a/include/wabt/feature.def
+++ b/include/wabt/feature.def
@@ -40,3 +40,4 @@ WABT_FEATURE(memory64,            "memory64",                false,   "64-bit me
 WABT_FEATURE(multi_memory,        "multi-memory",            false,   "Multi-memory")
 WABT_FEATURE(extended_const,      "extended-const",          false,   "Extended constant expressions")
 WABT_FEATURE(relaxed_simd,        "relaxed-simd",            false,   "Relaxed SIMD")
+WABT_FEATURE(sandbox,             "sandbox",                 true,    "Use WASM sandbox (disabling is experimental)")

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1396,7 +1396,7 @@ Result BinaryReaderIR::OnDataSegmentData(Index index,
   if (size > 0) {
     memcpy(segment->data.data(), data, size);
   }
-  if (options_.no_sandbox) {
+  if (!options_.features.sandbox_enabled()) {
     Offset offset = GetDataSegmentOffset(segment);
     if (offset == kInvalidOffset) {
       PrintError(
@@ -1536,7 +1536,7 @@ Result BinaryReaderIR::SetMemoryName(Index index, std::string_view name) {
   if (name.empty()) {
     return Result::Ok;
   }
-  if (options_.no_sandbox && index > 0) {
+  if (!options_.features.sandbox_enabled() && index > 0) {
     PrintError("multiple memories used in no-sandbox mode");
     return Result::Error;
   }
@@ -1652,7 +1652,7 @@ Result BinaryReaderIR::OnReloc(RelocType type,
                                Offset offset,
                                Index index,
                                uint32_t addend) {
-  if (!options_.no_sandbox) {
+  if (options_.features.sandbox_enabled()) {
     return Result::Ok;
   }
   switch (type) {

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -58,9 +58,9 @@ examples:
 
 static const std::string supported_features[] = {
     "multi-memory", "multi-value", "sign-extend", "saturating-float-to-int",
-    "exceptions",   "memory64",    "no-sandbox"};
+    "exceptions",   "memory64",    "sandbox"};
 
-static const std::string experimental_features[] = {"no-sandbox"};
+static const std::string experimental_features[] = {"sandbox"};
 
 static bool IsFeatureSupported(const std::string& feature) {
   return std::find(std::begin(supported_features), std::end(supported_features),

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -58,17 +58,24 @@ examples:
 
 static const std::string supported_features[] = {
     "multi-memory", "multi-value", "sign-extend", "saturating-float-to-int",
-    "exceptions",   "memory64"};
+    "exceptions",   "memory64",    "no-sandbox"};
+
+static const std::string experimental_features[] = {"no-sandbox"};
 
 static bool IsFeatureSupported(const std::string& feature) {
   return std::find(std::begin(supported_features), std::end(supported_features),
                    feature) != std::end(supported_features);
 };
 
+static bool IsFeatureExperimental(const std::string& feature) {
+  return std::find(std::begin(experimental_features),
+                   std::end(experimental_features),
+                   feature) != std::end(experimental_features);
+}
+
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm2c", s_description);
   bool experimental_flag_is_set = false;
-  bool experimental_feature_enabled = false;
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
@@ -93,13 +100,6 @@ static void ParseOptions(int argc, char** argv) {
                    []() { s_read_debug_names = false; });
   parser.AddOption("experimental", "Enable flags marked as (Experimental)\n",
                    [&]() { experimental_flag_is_set = true; });
-  parser.AddOption("no-sandbox",
-                   "(Experimental) Disable all sandboxing and unify host and\n"
-                   "WebAssembly address space for maximum compatibility.\n",
-                   [&]() {
-                     s_write_c_options.no_sandbox = true;
-                     experimental_feature_enabled = true;
-                   });
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) {
                        s_infile = argument;
@@ -107,25 +107,28 @@ static void ParseOptions(int argc, char** argv) {
                      });
   parser.Parse(argc, argv);
 
-  // Check that experimental flag is set for experimental features.
-  if (experimental_feature_enabled && !experimental_flag_is_set) {
-    fprintf(stderr,
-            "Some enabled features are experimental please set --experimental "
-            "flag to enable them.\n");
-    exit(1);
-  }
+  s_write_c_options.no_sandbox = !s_features.sandbox_enabled();
 
   bool any_non_supported_feature = false;
-#define WABT_FEATURE(variable, flag, default_, help)   \
-  any_non_supported_feature |=                         \
-      (s_features.variable##_enabled() != default_) && \
-      !IsFeatureSupported(flag);
+  bool any_experimental_feature = false;
+#define WABT_FEATURE(variable, flag, default_, help)                           \
+  any_non_supported_feature |=                                                 \
+      (s_features.variable##_enabled() != default_) &&                         \
+      !IsFeatureSupported(flag);                                               \
+  any_experimental_feature |= (s_features.variable##_enabled() != default_) && \
+                              IsFeatureExperimental(flag);
 #include "wabt/feature.def"
 #undef WABT_FEATURE
 
   if (any_non_supported_feature) {
     fprintf(stderr,
             "wasm2c currently only supports a limited set of features.\n");
+    exit(1);
+  }
+  if (!experimental_flag_is_set && any_experimental_feature) {
+    fprintf(stderr,
+            "Some enabled features are experimental please set --experimental "
+            "flag to enable them.\n");
     exit(1);
   }
 }
@@ -153,9 +156,9 @@ int ProgramMain(int argc, char** argv) {
     Module module;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = true;
-    ReadBinaryOptions options(
-        s_features, s_log_stream.get(), s_read_debug_names, kStopOnFirstError,
-        kFailOnCustomSectionError, s_write_c_options.no_sandbox);
+    ReadBinaryOptions options(s_features, s_log_stream.get(),
+                              s_read_debug_names, kStopOnFirstError,
+                              kFailOnCustomSectionError);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -31,6 +31,7 @@ options:
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions
       --enable-relaxed-simd                    Enable Relaxed SIMD
+      --disable-sandbox                        Disable Use WASM sandbox (disabling is experimental)
       --enable-all                             Enable all features
   -V, --value-stack-size=SIZE                  Size in elements of the value stack
   -C, --call-stack-size=SIZE                   Size in elements of the call stack

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -42,6 +42,7 @@ options:
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions
       --enable-relaxed-simd                    Enable Relaxed SIMD
+      --disable-sandbox                        Disable Use WASM sandbox (disabling is experimental)
       --enable-all                             Enable all features
   -V, --value-stack-size=SIZE                  Size in elements of the value stack
   -C, --call-stack-size=SIZE                   Size in elements of the call stack

--- a/test/help/wasm-opcodecnt.txt
+++ b/test/help/wasm-opcodecnt.txt
@@ -32,6 +32,7 @@ options:
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions
       --enable-relaxed-simd                    Enable Relaxed SIMD
+      --disable-sandbox                        Disable Use WASM sandbox (disabling is experimental)
       --enable-all                             Enable all features
   -o, --output=FILENAME                        Output file for the opcode counts, by default use stdout
   -c, --cutoff=N                               Cutoff for reporting counts less than N

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -31,6 +31,7 @@ options:
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions
       --enable-relaxed-simd                    Enable Relaxed SIMD
+      --disable-sandbox                        Disable Use WASM sandbox (disabling is experimental)
       --enable-all                             Enable all features
       --no-debug-names                         Ignore debug names in the binary file
       --ignore-custom-section-errors           Ignore errors in custom sections

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -37,6 +37,7 @@ options:
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions
       --enable-relaxed-simd                    Enable Relaxed SIMD
+      --disable-sandbox                        Disable Use WASM sandbox (disabling is experimental)
       --enable-all                             Enable all features
       --inline-exports                         Write all exports inline
       --inline-imports                         Write all imports inline

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -34,6 +34,7 @@ options:
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions
       --enable-relaxed-simd                    Enable Relaxed SIMD
+      --disable-sandbox                        Disable Use WASM sandbox (disabling is experimental)
       --enable-all                             Enable all features
   -o, --output=FILE                            output JSON file
   -r, --relocatable                            Create a relocatable wasm binary (suitable for linking with e.g. lld)

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -41,6 +41,7 @@ options:
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions
       --enable-relaxed-simd                    Enable Relaxed SIMD
+      --disable-sandbox                        Disable Use WASM sandbox (disabling is experimental)
       --enable-all                             Enable all features
       --generate-names                         Give auto-generated names to non-named functions, types, etc.
 ;;; STDOUT ;;)

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -41,6 +41,7 @@ options:
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions
       --enable-relaxed-simd                    Enable Relaxed SIMD
+      --disable-sandbox                        Disable Use WASM sandbox (disabling is experimental)
       --enable-all                             Enable all features
   -o, --output=FILE                            Output wasm binary file. Use "-" to write to stdout.
   -r, --relocatable                            Create a relocatable wasm binary (suitable for linking with e.g. lld)

--- a/test/wasm2c/no-sandbox/stack-pointer-shared.txt
+++ b/test/wasm2c/no-sandbox/stack-pointer-shared.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
-;;; ARGS: --debug-names --experimental --enable-memory64 --no-sandbox
+;;; ARGS: --debug-names --experimental --enable-memory64 --disable-sandbox
 ;;; STDIN_FILE: test/wasm2c/no-sandbox/wast/stack_pointer_shared.wast
 (;; STDOUT ;;;
 2/2 tests passed.

--- a/test/wasm2c/no-sandbox/stack-pointer.txt
+++ b/test/wasm2c/no-sandbox/stack-pointer.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
-;;; ARGS: --debug-names --enable-memory64 --no-sandbox --experimental
+;;; ARGS: --debug-names --enable-memory64 --disable-sandbox --experimental
 ;;; STDIN_FILE: test/wasm2c/no-sandbox/wast/stack_pointer.wast
 (;; STDOUT ;;;
 2/2 tests passed.


### PR DESCRIPTION
This removes the add-hoc --no-sandbox flag from wasm2c and instead makes "sandbox" an WABT feature that is available across all tools.  From now on, specify --disable-sandbox instead of --no-sandbox.

This is needed for the relaxed validation PR that will follow immediately.