### PR TITLE
Take symbol offsets into account.

### DIFF
--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -1258,8 +1258,10 @@ struct Module {
 
   // Mappings from a symbol index (pointing into the symbol table from the
   // "linking" section) to their corresponding function- and data segment index.
+  // The data segment index is paired with an offset relative to the beginning of
+  // that data segment.
   std::unordered_map<Index, Index> function_symbols_;
-  std::unordered_map<Index, Index> data_symbols_;
+  std::unordered_map<Index, std::pair<Index, uint32_t>> data_symbols_;
 
   // Mapping from a data symbol index to its name.  This mapping is only
   // constructed for data symbols that are marked undefined.

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1740,7 +1740,7 @@ Result BinaryReaderIR::OnDataSymbol(Index index,
     module_->undefined_data_symbols_[index] = name;
     return Result::Ok;
   }
-  module_->data_symbols_[index] = segment;
+  module_->data_symbols_[index] = { segment, offset };
   if (name.empty()) {
     return Result::Ok;
   }

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -4572,11 +4572,12 @@ void CWriter::WriteDataAddress(Index symbol_index,
         module_->undefined_data_symbols_.at(symbol_index);
     Write(external_name);
   } else {
-    Index data_segment_index = data_segment_index_ptr->second;
+    auto [data_segment_index, offset] = data_segment_index_ptr->second;
     const std::string& data_segment_name =
         module_->data_segments[data_segment_index]->name;
     Write("data_segment_data_",
           GlobalName(ModuleFieldType::DataSegment, data_segment_name));
+    addend += offset;
   }
   Write(")");
   if (addend > 0) {


### PR DESCRIPTION
Symbols that reside "inside" a data segment and
not at the beginning have a no-zero offset.  This
change remembers such offsets and adds it to the
addend when that symbol is being referred to later.