### PR TITLE
Generate proper main and include open proxies.

### DIFF
--- a/wasm2c/wasm-rt-no-sandbox-declarations.h
+++ b/wasm2c/wasm-rt-no-sandbox-declarations.h
@@ -106,4 +106,15 @@ DEFINE_STORE(i64_store32, u32, u64)
 
 // TODO: floating point
 
+extern u32 open(u64, u32, ...);
+
+inline static u32 wasm_open2(u64 p, u32 f) {
+  return open(p, f);
+}
+
+inline static u32 wasm_open3(u64 p, u32 f, u32 m) {
+  return open(p, f, m);
+}
+
+
 #endif /* WASM_RT_NO_SANDBOX_DECLARATIONS_H_ */


### PR DESCRIPTION
In no-sandbox mode, generate a "proper" main function when __main_argc_argv is being exported.  This "proper" main has the correct types and just calls the other with appropriate casts.

Also include definitions for WASM special functions wasm_open2 and wasm_open3.  Arrange for any "special" functions (starting with "wasm_") to not be considered imports.

Finally, move the declarations of data imports into the .c file. (There is no need for them to be in the .h file.)