### PR TITLE
Varargs call site handling

### DIFF
--- a/include/wabt/type.h
+++ b/include/wabt/type.h
@@ -55,6 +55,8 @@ class Type {
     I8U = 4,   // Not actually specified, but used internally with load/store
     I16U = 6,  // Not actually specified, but used internally with load/store
     I32U = 7,  // Not actually specified, but used internally with load/store
+
+    VarargsPlaceholder = 100,  // Represents variable argument portion of a varargs call
   };
 
   Type() = default;  // Provided so Type can be member of a union.

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2814,7 +2814,7 @@ void CWriter::WriteParamTypes(const FuncDeclaration& decl, bool is_varargs) {
       } else {
         needs_comma = true;
       }
-      if (is_varargs && i == decl.GetNumParams() - 1) {
+      if (is_varargs && (i == decl.GetNumParams() - 1)) {
         Write("...");
       } else {
         Write(decl.GetParamType(i));

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -3165,12 +3165,16 @@ void CWriter::Write(const ExprList& exprs) {
         // prepared:
         Index num_vparams = 0;
         if (va_prepared) {
-          assert(num_params >= 1);;
-          num_params -= 1;
+          assert(num_params >= 1);
           num_vparams = va_types.size();
           assert(StackType(0) == Type::VarargsPlaceholder);
-          DropTypes(1);  // Remove the placeholder.
-        }
+          // The last parameter of this call has no manifestation
+          // and merely represents the variable portion of the
+          // argument list.  It is removed here and later
+          // replaced with that variable portion.
+          DropTypes(1);
+          num_params -= 1;
+         }
 
         assert(type_stack_.size() >= num_params);
 
@@ -3180,7 +3184,7 @@ void CWriter::Write(const ExprList& exprs) {
           // We are calling a varargs function that is not imported, so it uses
           // WASM calling conventions.  This means we must place the variable
           // portion of the argument list on the stack and pass a pointer to
-          // that stack region as a single extra argument.
+          // that stack region as a single extra argument representing all of them.
           // The struct, named w2c_va_struct, is defined and initialized locally
           // within the scope previously opened when varargs were prepared:
           Write("struct ", OpenBrace());
@@ -3317,10 +3321,14 @@ void CWriter::Write(const ExprList& exprs) {
         Index num_vparams = 0;
         if (va_prepared) {
           assert(num_params >= 1);
-          num_params -= 1;
           num_vparams = va_types.size();
           assert(StackType(0) == Type::VarargsPlaceholder);
+          // The last parameter of this call has no manifestation
+          // and merely represents the variable portion of the
+          // argument list.  It is removed here and later
+          // replaced with that variable portion.
           DropTypes(1);
+          num_params -= 1;
         }
 
         // Write the fixed portion of the argument list:

--- a/src/interp/interp-util.cc
+++ b/src/interp/interp-util.cc
@@ -64,6 +64,7 @@ std::string TypedValueToString(const TypedValue& tv) {
     case Type::I8U:
     case Type::I16U:
     case Type::I32U:
+    case Type::VarargsPlaceholder:
       // These types are not concrete types and should never exist as a value
       WABT_UNREACHABLE;
   }


### PR DESCRIPTION
This PR implements handling of varargs at call sites
if those call sites are prepared (using a separate LLVM
patch) using intrinsics to allocate the variable
portion of the  respective argument list.

Without those intrinsics the behavior is unchanged.

Example:  Consider an imported function f with 2 regular
arguments plus an arbitrary number of additional arguments.

The additional arguments would be allocated by functions
of the form ___wasm_allocate_varargs_t1_t2_..._tn%f
where the ti are the types of the actual arguments at the call
site, and where the f after the % is the name of the actual
function being called.

Seeing a call of such a functions, wasm2c rewrites it by merging
its arguments back into the list of arguments of the surrounding
function call (namely that of f).  Moreover,
the generated declaration for f would show two arguments
(instead of 3) and add ... to the end.

For non-imported varargs functions, the translation of the
allocator call is a local struct that has the correct layout
for WASM varargs conventions, initialized using the
actual argument values from the call site.  The called
function receives a single additional argument that is
the address of this struct.
(This is a stop-gap until the callee-side of varargs has
been addressed as well.)

For the time being, varargs calls through function pointers assume
that the pointee is an imported function.

Everything here has been tested by translating the gzip benchmark
both with and without standalone-printf.c in the mix (thus testing both
import- and non-import scenarios).