### PR TITLE
Implements handling of struct return for all functions.

### DIFF
--- a/include/wabt/type.h
+++ b/include/wabt/type.h
@@ -57,6 +57,7 @@ class Type {
     I32U = 7,  // Not actually specified, but used internally with load/store
 
     VarargsPlaceholder = 100,  // Represents variable argument portion of a varargs call
+    SRetPointer = 101,         // Represents struct return pointer 
   };
 
   Type() = default;  // Provided so Type can be member of a union.

--- a/src/interp/interp-util.cc
+++ b/src/interp/interp-util.cc
@@ -65,6 +65,7 @@ std::string TypedValueToString(const TypedValue& tv) {
     case Type::I16U:
     case Type::I32U:
     case Type::VarargsPlaceholder:
+    case Type::SRetPointer:
       // These types are not concrete types and should never exist as a value
       WABT_UNREACHABLE;
   }

--- a/wasm2c/wasm-rt-no-sandbox-declarations.h
+++ b/wasm2c/wasm-rt-no-sandbox-declarations.h
@@ -17,6 +17,10 @@
 #ifndef WASM_RT_NO_SANDBOX_DECLARATIONS_H_
 #define WASM_RT_NO_SANDBOX_DECLARATIONS_H_
 
+struct w2c_sret_placeholder {
+  char c[128];
+};
+
 #define FUNC_PROLOGUE
 #define FUNC_EPILOGUE
 
@@ -374,16 +378,6 @@ static float wasm_sqrtf(float x) {
     return quiet_nanf(x);
   }
   return sqrtf(x);
-}
-
-extern u32 open(u64, u32, ...);
-
-inline static u32 wasm_open2(u64 p, u32 f) {
-  return open(p, f);
-}
-
-inline static u32 wasm_open3(u64 p, u32 f, u32 m) {
-  return open(p, f, m);
 }
 
 #endif /* WASM_RT_NO_SANDBOX_DECLARATIONS_H_ */


### PR DESCRIPTION
Includes handling of defined functions (as opposed to imported functions) that return structs by value.

The handling is driven by special marker function calls:  __wasm_sret_arg and __wasm_sret_entry

A corresponding change to llvm is needed to generate these marker function calls.